### PR TITLE
Fix for Zoom screen sharing blacked out

### DIFF
--- a/config/awesome/configuration/picom.conf
+++ b/config/awesome/configuration/picom.conf
@@ -36,7 +36,11 @@ shadow-exclude = [
   "class_g = 'Firefox' && window_type *= 'utility'",
 	"class_g = 'Firefox' && argb",
   "_GTK_FRAME_EXTENTS@:c",
-  "_NET_WM_STATE@:32a *= '_NET_WM_STATE_HIDDEN'"
+  "_NET_WM_STATE@:32a *= '_NET_WM_STATE_HIDDEN'",
+  "class_g *?= 'zoom'",
+  "name = 'cpt_frame_window'",
+  "name = 'as_toolbar'",
+  "name = 'cpt_frame_xcb_window'"
 ];
 
 
@@ -98,7 +102,8 @@ blur-background-exclude = [
   "window_type = 'notification'",
   "window_type = 'dropdown_menu'",
   "window_type = 'utility'",
-	"_GTK_FRAME_EXTENTS@:c"
+	"_GTK_FRAME_EXTENTS@:c",
+  "class_g = 'zoom'"
 ];
 
 


### PR DESCRIPTION
If you use zoom screen sharing feature the monitor that you share will be very dark because of picom making a shadow below the sharing window. Here is a fix to disable the shadow for screen sharing x windows