### PR TITLE
Fix battery percentage error causing crash

### DIFF
--- a/config/awesome/signal/battery.lua
+++ b/config/awesome/signal/battery.lua
@@ -5,7 +5,7 @@
 ---      state
 local upower_widget = require("modules.UPower")
 local battery_listener = upower_widget({
-	device_path = "/org/freedesktop/UPower/devices/battery_BAT0",
+	device_path = "/org/freedesktop/UPower/devices/battery_BAT1",
 	instant_update = true,
 })
 


### PR DESCRIPTION
Changing the battery device_path from BAT0 to BAT1 now solves null value on /config/awesome/modules/UPower/init.lua, that caused the entire setup to crash.