### PR TITLE
Fixing common issues

### DIFF
--- a/config/awesome/configuration/autostart.lua
+++ b/config/awesome/configuration/autostart.lua
@@ -5,8 +5,8 @@ local helpers = require("helpers")
 
 local function autostart_apps()
 	--- Compositor
-	helpers.run.check_if_running("picom --experimental-backends", nil, function()
-		awful.spawn("picom --experimental-backends --config " .. config_dir .. "configuration/picom.conf", false)
+	helpers.run.check_if_running("picom", nil, function()
+		awful.spawn("picom --config " .. config_dir .. "configuration/picom.conf", false)
 	end)
 	--- Music Server
 	helpers.run.run_once_pgrep("mpd")

--- a/config/awesome/signal/battery.lua
+++ b/config/awesome/signal/battery.lua
@@ -1,14 +1,97 @@
---- This uses UPowerGlib.Device (https://lazka.github.io/pgi-docs/UPowerGlib-1.0/classes/Device.html)
---- Provides:
---- signal::battery
----      percentage
----      state
-local upower_widget = require("modules.UPower")
-local battery_listener = upower_widget({
-	device_path = "/org/freedesktop/UPower/devices/battery_BAT0",
-	instant_update = true,
-})
+local awful = require "awful"
+local gobject = require "gears.object"
+local gtable = require "gears.table"
+local gtimer = require "gears.timer"
+local wbase = require "wibox.widget.base"
+local UPower = require("lgi").require "UPowerGlib"
 
-battery_listener:connect_signal("upower::update", function(_, device)
-	awesome.emit_signal("signal::battery", device.percentage, device.state)
-end)
+local upower = {}
+local instance = nil
+
+function upower.list_devices()
+  local ret = {}
+  local devices = UPower.Client():get_devices()
+
+  for _, device in ipairs(devices) do
+    table.insert(ret, device:get_object_path())
+  end
+
+  return ret
+end
+
+function upower.get_device(path)
+  local devices = UPower.Client():get_devices()
+
+  for _, device in ipairs(devices) do
+    if device:get_object_path() == path then
+      return device
+    end
+  end
+
+  return nil
+end
+
+function upower.attach_to_device(args)
+  args = gtable.crush({
+    widget_template = wbase.empty_widget(),
+    device_path = "",
+    use_display_device = false,
+  }, args or {})
+
+  local widget = wbase.make_widget_from_value(args.widget_template)
+
+  widget.device = args.use_display_device and UPower.Client():get_display_device()
+    or upower.get_device(args.device_path)
+
+  widget.device.on_notify = function(d)
+    widget:emit_signal("upower::update", d)
+  end
+
+  if args.instant_update then
+    gtimer.delayed_call(widget.emit_signal, widget, "upower::update", widget.device)
+  end
+
+  return widget
+end
+
+local function new()
+  local ret = gobject {}
+  gtable.crush(ret, upower, true)
+
+  if UPower.Client():get_devices() == nil then
+    ret:emit_signal "no_devices"
+  else
+    awful.spawn.easy_async_with_shell("echo $(upower -e | grep 'BAT' | head -n 1)", function(stdout)
+      local device = stdout:gsub("\n", "")
+      if device == "" then
+        ret:emit_signal "no_devices"
+      else
+        ret:emit_signal("raw_devices", device)
+        ret
+          .attach_to_device({
+            device_path = stdout:gsub("\n", ""),
+            instant_update = true,
+          })
+          :connect_signal("upower::update", function(_, device)
+            local time_to_empty = device.time_to_empty / 60
+            local time_to_full = device.time_to_full / 60
+            ret:emit_signal(
+              "update",
+              tonumber(string.format("%.0f", device.percentage)),
+              device.state,
+              tonumber(string.format("%.0f", time_to_empty)),
+              tonumber(string.format("%.0f", time_to_full)),
+              device.battery_level
+            )
+          end)
+      end
+    end)
+  end
+
+  return ret
+end
+
+if not instance then
+  instance = new()
+end
+return instance

--- a/config/awesome/ui/decorations/titlebar.lua
+++ b/config/awesome/ui/decorations/titlebar.lua
@@ -18,6 +18,10 @@ local tabbed_misc = bling.widget.tabbed_misc
 
 --- Add a titlebar if titlebars_enabled is set to true in the rules.
 client.connect_signal("request::titlebars", function(c)
+	if c.requests_no_titlebar then
+		return
+	end
+
 	awful
 		.titlebar(c, { position = "top", size = dpi(36), font = beautiful.font_name .. "Medium 10", bg = beautiful.transparent })
 		:setup({

--- a/config/awesome/ui/notifications/init.lua
+++ b/config/awesome/ui/notifications/init.lua
@@ -132,7 +132,7 @@ naughty.connect_signal("request::display", function(n)
 	local dismiss = widgets.button.text.normal({
 		font = beautiful.icon_font .. "Round ",
 		paddings = dpi(2),
-		size = 10,
+		size = 8,
 		bold = true,
 		text = "",
 		text_normal_bg = accent_colors,

--- a/config/awesome/ui/panels/top-panel/battery.lua
+++ b/config/awesome/ui/panels/top-panel/battery.lua
@@ -1,7 +1,7 @@
 local awful = require("awful")
 local wibox = require("wibox")
 local beautiful = require("beautiful")
-require("signal.battery")
+local upower_daemon = require("signal.battery")
 local gears = require("gears")
 local apps = require("configuration.apps")
 local dpi = require("beautiful").xresources.apply_dpi
@@ -96,7 +96,12 @@ return function()
 	})
 
 	local last_value = 100
-	awesome.connect_signal("signal::battery", function(value, state)
+
+	upower_daemon:connect_signal("no_devices", function (_)
+		widget.visible = false
+	end)
+
+	upower_daemon:connect_signal("update", function (self, value, state)
 		battery_bar.value = value
 		last_value = value
 


### PR DESCRIPTION
This PR aims to fix some common issues that i found when testing yoru on my machine, i've refactored some things to make them dynamically like the battery widget. the next list will describe in more detail what my changes was about:

- decreased a little the font size for the dismiss notification button which was looking kinda weird (looking like `...`) on 1920x1080, this doesn't matters too much but idk, it's great to have like this i guess.
- i've added a validation for the c.requests_no_titlebar property in the titlebars definition to don't apply titlebars for apps which don't wanna get them.
- complete refactor for the battery/upower signals to make them autodetect the device + check if there's no device running (useful for desktop computers, or laptops without battery per example).
- removing --experimental-backends on picom cuz idk it was showing in xephyr logs that it didn't exist anymore
- i've see that if i change the github username, the github widget didn't refresh if i didn't do something like `rm -rf ~/.cache/awesome`, so i've added a code block which removes ~/.config/awesome/github if it sees that im changing that username credential by using a new cache file in ~/.config/awesome/github/username.txt.

> im open to suggestions in general :)