### PR TITLE
Fix: top panel hidden after fullscreen/maximized client

### DIFF
--- a/config/awesome/ui/panels/top-panel/init.lua
+++ b/config/awesome/ui/panels/top-panel/init.lua
@@ -303,5 +303,5 @@ return function(s)
 	end)
 
 	client.connect_signal("property::fullscreen", remove_top_panel)
-	client.connect_signal("request::unmanage", add_top_panel)
+	client.connect_signal("unfocus", add_top_panel)
 end


### PR DESCRIPTION
Fixes issues #169 and #160.

request::unmanage is at fault, it's not being emitted when we desire to return the top panel back.

From docs:
[request::manage](https://awesomewm.org/apidoc/core_components/client.html#request::manage)	Emitted when a new client appears and gets managed by Awesome.
What we would much rather desire is:
[unfocus](https://awesomewm.org/apidoc/core_components/client.html#unfocus)	Emitted when a client gets unfocused.

We don't have to worry about getting panel when going from fullscreen to fullscreen on another workspace, as this case will trigger add_top_panel and then remove_top_panel sequentially.